### PR TITLE
Dash recipes fix

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -105,6 +105,7 @@ body {
   border: none;
   border-radius: 0;
   box-shadow: 2px 6px 8px 0 rgba(22, 22, 26, 0.18);
+  width: calc(100%/3)
 }
 
 .cards-wrapper {

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -6,7 +6,7 @@
   <div class="carousel-inner">
     <div class="carousel-item active">
       <div class="cards-wrapper">
-      <% @favorite_recipes.each do |recipe| %>
+      <% @favorite_recipes.sample(3).each do |recipe| %>
         <div class="card carousel-card" style="">
           <div class="image-wrapper">
             <img src="https://static.toiimg.com/thumb/78028918.cms?width=680&height=512&imgsize=2041089" alt="...">
@@ -22,15 +22,15 @@
     </div>
     <div class="carousel-item">
       <div class="cards-wrapper">
-      <% 3.times do %>
+      <% @favorite_recipes.sample(3).each do |recipe| %>
         <div class="card carousel-card" style="">
           <div class="image-wrapper">
             <img src="https://static.toiimg.com/thumb/78028918.cms?width=680&height=512&imgsize=2041089" alt="...">
           </div>
           <div class="card-body">
-            <h5 class="card-title">Recipe Name</h5>
-            <p class="card-text">Some quick example text to build on the card title and make up the bulk of the card's content.</p>
-            <a href="#" class="btn btn-primary">See Recipe</a>
+            <h5 class="card-title"><%= recipe.name %></h5>
+            <p class="card-text"><%= recipe.description %></p>
+            <%= link_to "See Recipe", recipe_path(id: recipe.id), class: "btn btn-primary" %>
           </div>
         </div>
         <% end %>


### PR DESCRIPTION
This fixes the weird styling issue on the user dashboard to have consistent styling with the recipe cards, and randomly selects from 3 recipes for the iteration for specificity. This also fixes the second part of the carousel that displayed the sample cards versus the actual favorited recipes. It now consistently displays 6 randomly generated favorited recipes for the user dash.

<img src="https://media3.giphy.com/media/WQTqIoim4mjrcY9BAW/giphy-downsized-medium.gif"/>